### PR TITLE
Player object fix

### DIFF
--- a/espncricinfo/exceptions.py
+++ b/espncricinfo/exceptions.py
@@ -25,3 +25,9 @@ class NoSeriesError(TypeError):
     Exception raised if a series_id is not valid or does not exist.
     """
     pass
+
+class TeamNotFoundError(TypeError):
+    """
+    Exception raised if a players majorTeam is unable to be found
+    """
+    pass

--- a/espncricinfo/player.py
+++ b/espncricinfo/player.py
@@ -64,6 +64,7 @@ class Player(object):
         teams = []
         for x in self.json['majorTeams']:
             r = requests.get(x['$ref'])
+            print(x['$ref'])
             if r.status_code == 404:
                 # is new error required
                 raise TeamNotFoundError

--- a/espncricinfo/player.py
+++ b/espncricinfo/player.py
@@ -64,9 +64,7 @@ class Player(object):
         teams = []
         for x in self.json['majorTeams']:
             r = requests.get(x['$ref'])
-            print(x['$ref'])
             if r.status_code == 404:
-                # is new error required
                 raise TeamNotFoundError
             else:
                 teams.append(r.json()['name'])


### PR DESCRIPTION
### Player Object Update - Major Teams (_major_teams)
This attempts to fix issue [[BUG] Player class is not working with Python 3.11.0 #59](https://github.com/outside-edge/python-espncricinfo/issues/59)

The ESPN CricInfo html page has been updated with class and syntax changes which mean the previous _major_teams function did not work:
```
def _major_teams(self):
        return [x.text for x in self.parsed_html.find('div', class_='overview-teams-grid').find_all('h5')]
```
The JSON for each player provides a list of their teams through links with links like [http://core.espnuk.org/v2/sports/cricket/teams/2](http://core.espnuk.org/v2/sports/cricket/teams/2)

I have written an updated function that visits gets each of these json files, gets the team name and appends the names to a list which is then returned
```
def _major_teams(self):
        teams = []
        for x in self.json['majorTeams']:
            r = requests.get(x['$ref'])
            if r.status_code == 404:
                raise TeamNotFoundError
            else:
                teams.append(r.json()['name'])
        return teams
```
I also wrote a new error in exceptions.py to handle the 404 HTTP errors - TeamNotFoundError

### Time consideration
Unfortunately, due to the manner in which this function individually requests each team page, the function is considerably slower the before. Further players with a large amount of teams, eg. Steve Smith take up ~16 seconds. This seriosuly affects the usage of the function. For this reason there may be another way to get the major teams, for example seperate this function from the rest.