### PR TITLE
New player endpoint for major_teams

### DIFF
--- a/espncricinfo/exceptions.py
+++ b/espncricinfo/exceptions.py
@@ -25,9 +25,3 @@ class NoSeriesError(TypeError):
     Exception raised if a series_id is not valid or does not exist.
     """
     pass
-
-class TeamNotFoundError(TypeError):
-    """
-    Exception raised if a players majorTeam is unable to be found
-    """
-    pass

--- a/espncricinfo/exceptions.py
+++ b/espncricinfo/exceptions.py
@@ -25,3 +25,9 @@ class NoSeriesError(TypeError):
     Exception raised if a series_id is not valid or does not exist.
     """
     pass
+
+class TeamNotFoundError(TypeError):
+    """
+    Exception raised if a players majorTeam is unable to be found
+    """
+    pass

--- a/espncricinfo/player.py
+++ b/espncricinfo/player.py
@@ -10,7 +10,7 @@ class Player(object):
     def __init__(self, player_id):
         self.player_id=player_id
         self.url = "https://www.espncricinfo.com/player/player-name-{0}".format(str(player_id))
-        self.json_url = "http://core.espnuk.org/v2/sports/cricket/athletes/{0}".format(str(player_id))
+        self.json_url = "https://hs-consumer-api.espncricinfo.com/v1/pages/player/home?playerId={0}".format(str(player_id))
         self.parsed_html = self.get_html() 
         self.json = self.get_json()       
         self.cricinfo_id = str(player_id)

--- a/espncricinfo/player.py
+++ b/espncricinfo/player.py
@@ -1,7 +1,7 @@
 import requests
 from bs4 import BeautifulSoup
 import dateparser
-from espncricinfo.exceptions import PlayerNotFoundError, TeamNotFoundError
+from espncricinfo.exceptions import PlayerNotFoundError
 from espncricinfo.match import Match
 import csv
 

--- a/espncricinfo/player.py
+++ b/espncricinfo/player.py
@@ -64,6 +64,7 @@ class Player(object):
         teams = []
         for x in self.json['majorTeams']:
             r = requests.get(x['$ref'])
+            print(x['$ref'])
             if r.status_code == 404:
                 # is new error required
                 raise TeamNotFoundError

--- a/espncricinfo/player.py
+++ b/espncricinfo/player.py
@@ -64,9 +64,7 @@ class Player(object):
         teams = []
         for x in self.json['majorTeams']:
             r = requests.get(x['$ref'])
-            print(x['$ref'])
             if r.status_code == 404:
-                # is new error required
                 raise TeamNotFoundError
             else:
                 teams.append(r.json()['name'])


### PR DESCRIPTION
### Player Object Update - Major Teams (_major_teams)
This attempts to fix issue [[BUG] Player class is not working with Python 3.11.0 #59](https://github.com/outside-edge/python-espncricinfo/issues/59)

The ESPN Cricinfo html page has been updated with class and syntax changes which mean the previous _major_teams function did not work:
```
def _major_teams(self):
        return [x.text for x in self.parsed_html.find('div', class_='overview-teams-grid').find_all('h5')]
```
There is a new endpoint which the ESPN Cricinfo page appears to utilise for player data (or in conjunction with the previous). Example: [(https://hs-consumer-api.espncricinfo.com/v1/pages/player/home?playerId=7069)](https://hs-consumer-api.espncricinfo.com/v1/pages/player/home?playerId=7069)

This provides similar data to the previous endpoint, however there are some differences. For this reason I have only modified the major_teams function with this in order to get it functional (with which the rest are).
```
def _major_teams(self):
        return [x['team']['longName'] for x in self.new_json['content']['teams']]
```

Eventually it would most likely be wise to update the rest of the functions to the latest 'endpoint' but for now this fixes previous problems.